### PR TITLE
add-pdf-only-mode

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,7 +1,8 @@
 <config>
     <!-- General-Settings -->
     <scriptlang>ENG</scriptlang>   <!-- Language of this script and the greeting-text on your pdf-files. Currently supported: German (GER), English (ENG), French (FRA), Spanish (SPA) -->
-    
+    <pdf_only>no</pdf_only> <!-- choose 'yes' if you want to create a pdf-file with the user data without send data to api server -->
+
     <!-- Sensitive data! Delete this information after successful data import -->
     <cloudurl>mycloud.mydomain.org</cloudurl> <!-- CHANGE THIS to your cloud domain, e.g. mycloud.mydomain.org or www.mydomain.org/mycloud (without https://) -->
     <adminname>Cloudadmin</adminname> <!-- CHANGE THIS to your cloud user, who has admin permissions-->

--- a/lang/ENG.json
+++ b/lang/ENG.json
@@ -26,6 +26,8 @@
     "nc_userimporter_enter_choice": "Enter your choice (1/2/3):",
     "nc_userimporter_invalid_choice": "Invalid choice, please try again.",
     "nc_userimporter_attention_no_password_set": "ATTENTION: You have specified that users for whom no password has been entered will receive an e-mail to set a password for themselves. Please make absolutely sure that a correct e-mail address is entered for every user for whom no password has been set!",
+    "nc_userimporter_pdfonly_mode": "Test mode: PDF generation only, without sending data to the API.",
+    "nc_userimporter_pdfonly_mode_done": "Test mode: PDF files successfully generated.",
     "output_handler_greeting": "Hello",
     "output_handler_account_created": "A Nextcloud account has been created for you.",
     "output_handler_login_instructions": "You can log in with the following credentials:",

--- a/lang/RUS.json
+++ b/lang/RUS.json
@@ -26,6 +26,8 @@
     "nc_userimporter_enter_choice": "Введите ваш выбор (1/2/3):",
     "nc_userimporter_invalid_choice": "Неверный выбор, попробуйте снова.",
     "nc_userimporter_attention_no_password_set": "ВНИМАНИЕ: Вы указали, что пользователи, для которых не задан пароль, получат электронное письмо для самостоятельной установки пароля. Пожалуйста, убедитесь, что для каждого пользователя, для которого не задан пароль, введен правильный адрес электронной почты!",
+    "nc_userimporter_pdfonly_mode": "Тестовый режим: только генерация PDF, без отправки данных на API.",
+    "nc_userimporter_pdfonly_mode_done": "Тестовый режим: PDF-файлы успешно сгенерированы.",
     "output_handler_greeting": "Здравствуйте",
     "output_handler_account_created": "Для вас создан аккаунт Nextcloud.",
     "output_handler_login_instructions": "Вы можете войти, используя следующие учетные данные:",

--- a/modules/config.py
+++ b/modules/config.py
@@ -48,7 +48,7 @@ class ConfigReader:
         config_keys = [
             'cloudurl', 'adminname', 'adminpass', 'csvfile', 'csvdelimiter',
             'csvdelimitergroups', 'generatepassword', 'passwordlength',
-            'sslverify', 'language', 'pdf_one_file', 'pdf_single_files', 'loglevel', 'scriptlang'
+            'sslverify', 'language', 'pdf_one_file', 'pdf_only', 'pdf_single_files', 'loglevel', 'scriptlang'
         ]
 
         # Dictionary to hold key-value pairs from the XML configuration file


### PR DESCRIPTION
- Added a new 'pdf_only' mode to generate PDFs without creating users in Nextcloud.
- Introduced 'pdf_only' configuration parameter with default set to 'no'.
- Modified user creation logic to skip API calls when 'pdf_only' is enabled.
- Added Russian locale messages for PDF-only test mode to clarify that no data is sent to the API and confirm PDF creation.
- Refactored user creation and app password handling to unify data processing for both modes.
- Implemented static method for password generation and retrieval of app passwords via API for QR code generation, with fallback to regular password.
- Improved logging with warnings and errors in Russian for app password retrieval failures and user creation issues.